### PR TITLE
fix(Mapper): fix AssociatedBehaviour only needs to be set if map used, also was missing Street Reference

### DIFF
--- a/src/Mappers/FloodingRequestMapper.cs
+++ b/src/Mappers/FloodingRequestMapper.cs
@@ -26,7 +26,6 @@ namespace flooding_service.Mappers
                 },
                 Description = DescriptionBuilder(floodingRequest),
                 RaisedByBehaviour = RaisedByBehaviourEnum.Individual,
-                AssociatedWithBehaviour = AssociatedWithBehaviourEnum.Street
             };
 
             if (floodingRequest.DidNotUseMap)
@@ -34,16 +33,19 @@ namespace flooding_service.Mappers
                 crmCase.Street = new Street
                 {
                     USRN = ConfirmConstants.USRN,
-                    Description = ConfirmConstants.Description
+                    Description = ConfirmConstants.Description,
+                    Reference = ConfirmConstants.USRN
                 };
             }
             else
             {
+                crmCase.AssociatedWithBehaviour = AssociatedWithBehaviourEnum.Street;
                 var street = floodingRequest.Map?.Street.Split(',').ToList();
                 crmCase.Street = new Street
                 {
                     USRN = street.Last().Trim(),
-                    Description = street.SkipLast(1).Aggregate("",(x,y) => x + y + ',').Trim(',')
+                    Description = street.SkipLast(1).Aggregate("",(x,y) => x + y + ',').Trim(','),
+                    Reference = street.Last().Trim()
                 };
             }
 


### PR DESCRIPTION
### Description
The AssociatedBehaviour for street only needs to be set if the map is used so moved it into the 'else'. It also wasn't associating the street, we think because we were missing the Reference in the crm.Street obj


### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary